### PR TITLE
pyexec executes stuff in binaries/Win32/Mods at the moment (probably a holdover from before the filesystem changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note that using `WINEDLLOVERRIDES` for `ddraw` isn't supported by the Wine devel
 ## Usage
 
 `py <python code>` runs arbitrary python code.  
-`pyexec <python file>` runs arbitrary python files from `binaries/Win32/Plugins/Python/`.
+`pyexec <python file>` runs arbitrary python files from `binaries/Win32/Mods/`.
 
 ## Borderlands Ingame Mod Manager
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ If you are asked to overwrite any files, accept. This mod replaces (and function
 
 ### Linux (SteamPlay/Proton and Wine)
 
-PythonSDK seems to work well under SteamPlay/Proton and Wine, but Wine needs to be told to allow `ddraw.dll` overrides.  Set the game's launch options (via `Properties -> General`) to `WINEDLLOVERRIDES="ddraw=n,b" %command%`
+PythonSDK does not yet work natively on Linux, but it seems to work well under SteamPlay/Proton and Wine.  To load properly, though, Wine needs to be told to allow `ddraw.dll` overrides.  Set the game's launch options (via `Properties -> General`) to `WINEDLLOVERRIDES="ddraw=n,b" %command%`
+
+Note that using `WINEDLLOVERRIDES` for `ddraw` isn't supported by the Wine developers, so if you experience problems with the game while using this method, please don't ask the WineHQ team for assistance.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ If you are asked to overwrite any files, accept. This mod replaces (and function
 
 3. If you have installed an older version of the SDK, delete the old files. This includes `Win32\Plugins\PythonSDK.dll`
 
+### Linux (SteamPlay/Proton and Wine)
+
+PythonSDK seems to work well under SteamPlay/Proton and Wine, but Wine needs to be told to allow `ddraw.dll` overrides.  Set the game's launch options (via `Properties -> General`) to `WINEDLLOVERRIDES="ddraw=n,b" %command%`
+
 ## Usage
 
 `py <python code>` runs arbitrary python code.  


### PR DESCRIPTION
Just what it says, trivial little README update.