### PR TITLE
Make the Linux TPS Launch Options explicit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ PythonSDK does not yet work natively on Linux, but it seems to work well under S
 
     WINEDLLOVERRIDES="ddraw=n,b" bash -c 'exec "${@/Launcher.exe/Borderlands2.exe}"' -- %command%
 
+Or, for TPS:
+
+    WINEDLLOVERRIDES="ddraw=n,b" bash -c 'exec "${@/Launcher.exe/BorderlandsPreSequel.exe}"' -- %command%
+
 Note that using `WINEDLLOVERRIDES` for `ddraw` isn't supported by the Wine developers, so if you experience problems with the game while using this method, please don't ask the WineHQ team for assistance.
 
 ## Usage


### PR DESCRIPTION
I suppose that it'd make sense to enumerate the TPS launch options for Linux as well, since it's technically different than on BL2 now.