### PR TITLE
Fixed UMaterialInstanceConstant::SetVectorParameterValue

### DIFF
--- a/src/UnrealEngine/Engine_functions.cpp
+++ b/src/UnrealEngine/Engine_functions.cpp
@@ -71497,6 +71497,7 @@ void UMaterialInstanceConstant::SetVectorParameterValue(const struct FName& Para
 
 	UMaterialInstanceConstant_SetVectorParameterValue_Params params;
 	params.ParameterName = ParameterName;
+	params.Value = *Value;
 
 	auto flags = fn->FunctionFlags;
 	fn->FunctionFlags |= 0x400;


### PR DESCRIPTION
Before the FLinearColor Value was not added to the params, resulting in unexpected behavior.