### PR TITLE
Keybind Improvements

### DIFF
--- a/Mods/ModMenu/SettingsManager.py
+++ b/Mods/ModMenu/SettingsManager.py
@@ -55,10 +55,12 @@ def SaveModSettings(mod: ModObjects.SDKMod) -> None:
 
         mod_settings[_OPTIONS_CATEGORY_NAME] = create_options_dict(mod.Options)
 
-    if len(mod.Keybinds) > 0:
+    if any(k.IsRebindable for k in mod.Keybinds):
         mod_settings[_KEYBINDS_CATEGORY_NAME] = {}
         for input in mod.Keybinds:
             if isinstance(input, KeybindManager.Keybind):
+                if not input.IsRebindable:
+                    continue
                 mod_settings[_KEYBINDS_CATEGORY_NAME][input.Name] = input.Key
             else:
                 dh.PrintWarning(KeybindManager.Keybind._list_deprecation_warning)


### PR DESCRIPTION
Adds fields `Keybind.IsRebindable` and `Keybind.IsHidden`. Binds which are not rebindable still show up in the menu so users can tell what they are, but can't be changed and aren't added to the settings file. Binds which are hidden don't appear in the menu, but are still in the settings file (unless they're also unrebindable). Binds with either flag will continue reviving events as normal.

Adds the `Keybind.OnPress` callback. If present, it will be called instead of `mod.GameInputPressed`. Has an optional input event argument in the exact same way as `mod.GameInputPressed`.