### PR TITLE
Minor Options Revamp

### DIFF
--- a/Mods/ModMenu/OptionManager.py
+++ b/Mods/ModMenu/OptionManager.py
@@ -14,8 +14,14 @@ _nested_options_stack: List[Options.Nested] = []
 _MOD_OPTIONS_EVENT_ID: int = 1417
 _MOD_OPTIONS_MENU_NAME: str = "MODS"
 
-_HEADER_OPTION_MARK: str = "_modmenu_header_option"
 _INDENT: int = 2
+
+
+class _ModHeader(Options.Field):
+    def __init__(self, Caption: str) -> None:
+        self.Caption = Caption
+        self.Description = ""
+        self.IsHidden = False
 
 
 def _create_data_provider(name: str) -> unrealsdk.UObject:
@@ -152,9 +158,7 @@ def _DataProviderOptionsBasePopulate(caller: unrealsdk.UObject, function: unreal
                     continue
                 if not one_shown:
                     one_shown = True
-                    header_option = Options.Field(mod.Name)
-                    setattr(header_option, _HEADER_OPTION_MARK, True)
-                    all_options.append(header_option)
+                    all_options.append(_ModHeader(mod.Name))
                 all_options.append(option)
 
         _nested_options_stack.append(Options.Nested(_MOD_OPTIONS_MENU_NAME, "", all_options))
@@ -164,7 +168,7 @@ def _DataProviderOptionsBasePopulate(caller: unrealsdk.UObject, function: unreal
         if option.IsHidden:
             continue
 
-        indent = " " * _INDENT if first_level and not hasattr(option, _HEADER_OPTION_MARK) else ""
+        indent = " " * _INDENT if first_level and not isinstance(option, _ModHeader) else ""
 
         if isinstance(option, Options.Spinner):
             spinner_idx: int
@@ -188,11 +192,9 @@ def _DataProviderOptionsBasePopulate(caller: unrealsdk.UObject, function: unreal
             )
         elif isinstance(option, Options.Field):
             disabled = False
-            caption = option.Caption
             if isinstance(option, Options.Nested):
                 disabled = not _is_anything_shown(option.Children)
-                caption += "¬"
-            params.TheList.AddListItem(idx, indent + caption, disabled, False)
+            params.TheList.AddListItem(idx, indent + option.Caption, disabled, False)
 
         caller.AddDescription(idx, option.Description)
 

--- a/Mods/ModMenu/Options.py
+++ b/Mods/ModMenu/Options.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Sequence, Tuple
+from typing import Any, Generic, Optional, Sequence, Tuple, TypeVar
 
 from . import DeprecationHelper as dh
 
@@ -13,6 +13,8 @@ __all__: Tuple[str, ...] = (
     "Spinner",
     "Value",
 )
+
+T = TypeVar("T")
 
 
 class Base(ABC):
@@ -39,7 +41,7 @@ class Base(ABC):
         raise NotImplementedError
 
 
-class Value(Base):
+class Value(Base, Generic[T]):
     """
     The abstract base class for all options that store a value.
 
@@ -52,22 +54,22 @@ class Value(Base):
 
         IsHidden: If the option is hidden from the options menu.
     """
-    CurrentValue: Any
-    StartingValue: Any
+    CurrentValue: T
+    StartingValue: T
 
     @abstractmethod
     def __init__(
         self,
         Caption: str,
         Description: str,
-        StartingValue: Any,
+        StartingValue: T,
         *,
         IsHidden: bool = True
     ) -> None:
         raise NotImplementedError
 
 
-class Hidden(Value):
+class Hidden(Value[T]):
     """
     A hidden option that never displays in the menu but stores an arbitrary (json serializable)
      value to the settings file.
@@ -81,11 +83,12 @@ class Hidden(Value):
         StartingValue: The default value of the option.
         IsHidden: If the option is hidden from the options menu. This is forced to True.
     """
+
     def __init__(
         self,
         Caption: str,
         Description: str = "",
-        StartingValue: Any = None,
+        StartingValue: T = None,  # type: ignore
         *,
         IsHidden: bool = True
     ) -> None:
@@ -117,7 +120,7 @@ class Hidden(Value):
         pass
 
 
-class Slider(Value):
+class Slider(Value[int]):
     """
     An option which allows users to select a value along a slider.
 
@@ -177,7 +180,7 @@ class Slider(Value):
         self.IsHidden = IsHidden
 
 
-class Spinner(Value):
+class Spinner(Value[str]):
     """
     An option which allows users to select one value from a sequence of strings.
 
@@ -243,7 +246,7 @@ class Spinner(Value):
             )
 
 
-class Boolean(Spinner):
+class Boolean(Spinner, Value[bool]):
     """
     A special form of a spinner, with two options representing boolean values.
 
@@ -257,6 +260,7 @@ class Boolean(Spinner):
 
         IsHidden: If the option is hidden from the options menu.
     """
+
     StartingValue: bool  # type: ignore
     Choices: Tuple[str, str]
 
@@ -320,32 +324,10 @@ class Field(Base):
         IsHidden: If the field is hidden from the options menu.
     """
 
-    def __init__(
-        self,
-        Caption: str,
-        Description: str = "",
-        *,
-        IsHidden: bool = False
-    ) -> None:
-        """
-        Creates the option.
-
-        Args:
-            Caption: The name of the option.
-            Description: A short description of the option to show when hovering over it in the menu.
-            IsHidden (keyword only): If the value is hidden from the options menu.
-        """
-        self.Caption = Caption
-        self.Description = Description
-        self.IsHidden = IsHidden
-
 
 class Nested(Field):
     """
     A field which when clicked opens up a nested menu with more options.
-
-    These are distinguished from normal fields by having the "new" exclaimation mark to the side of
-     it, but you should probably still give it a meaningful description.
 
     Note that these fields will be disabled if all child options are either hidden or other disabled
      nested fields.

--- a/Mods/ModMenu/Options.py
+++ b/Mods/ModMenu/Options.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from reprlib import recursive_repr
 from typing import Any, Generic, Optional, Sequence, Tuple, TypeVar
 
 from . import DeprecationHelper as dh
@@ -119,6 +120,16 @@ class Hidden(Value[T]):
     def IsHidden(self, val: bool) -> None:
         pass
 
+    @recursive_repr()
+    def __repr__(self) -> str:
+        return (
+            f"Hidden("
+            f"Caption={repr(self.Caption)},"
+            f"Description={repr(self.Description)},"
+            f"*,IsHidden={repr(self.IsHidden)}"
+            f")"
+        )
+
 
 class Slider(Value[int]):
     """
@@ -178,6 +189,21 @@ class Slider(Value[int]):
         self.MaxValue = MaxValue
         self.Increment = Increment
         self.IsHidden = IsHidden
+
+    @recursive_repr()
+    def __repr__(self) -> str:
+        return (
+            f"Slider("
+            f"Caption={repr(self.Caption)},"
+            f"Description={repr(self.Description)},"
+            f"CurrentValue={repr(self.CurrentValue)},"
+            f"StartingValue={repr(self.StartingValue)},"
+            f"MinValue={repr(self.MinValue)},"
+            f"MaxValue={repr(self.MaxValue)},"
+            f"Increment={repr(self.Increment)},"
+            f"*,IsHidden={repr(self.IsHidden)}"
+            f")"
+        )
 
 
 class Spinner(Value[str]):
@@ -245,6 +271,19 @@ class Spinner(Value[str]):
                 f"Provided starting value '{self.StartingValue}' is not in the list of choices."
             )
 
+    @recursive_repr()
+    def __repr__(self) -> str:
+        return (
+            f"Spinner("
+            f"Caption={repr(self.Caption)},"
+            f"Description={repr(self.Description)},"
+            f"CurrentValue={repr(self.CurrentValue)},"
+            f"StartingValue={repr(self.StartingValue)},"
+            f"Choices={repr(self.Choices)},"
+            f"*,IsHidden={repr(self.IsHidden)}"
+            f")"
+        )
+
 
 class Boolean(Spinner, Value[bool]):
     """
@@ -260,7 +299,6 @@ class Boolean(Spinner, Value[bool]):
 
         IsHidden: If the option is hidden from the options menu.
     """
-
     StartingValue: bool  # type: ignore
     Choices: Tuple[str, str]
 
@@ -312,6 +350,19 @@ class Boolean(Spinner, Value[bool]):
             self._current_value = bool(self.Choices.index(val))
         else:
             self._current_value = bool(val)
+
+    @recursive_repr()
+    def __repr__(self) -> str:
+        return (
+            f"Boolean("
+            f"Caption={repr(self.Caption)},"
+            f"Description={repr(self.Description)},"
+            f"CurrentValue={repr(self.CurrentValue)},"
+            f"StartingValue={repr(self.StartingValue)},"
+            f"Choices={repr(self.Choices)},"
+            f"*,IsHidden={repr(self.IsHidden)}"
+            f")"
+        )
 
 
 class Field(Base):
@@ -365,3 +416,14 @@ class Nested(Field):
         self.Description = Description
         self.Children = Children
         self.IsHidden = IsHidden
+
+    @recursive_repr()
+    def __repr__(self) -> str:
+        return (
+            f"Nested("
+            f"Caption={repr(self.Caption)},"
+            f"Description={repr(self.Description)},"
+            f"Children={repr(self.Children)},"
+            f"*,IsHidden={repr(self.IsHidden)}"
+            f")"
+        )


### PR DESCRIPTION
This introduces one breaking change: `Options.Field` is now abstract.

On the outermost modded options menu, all options, but not mod headers, are now indented, similarly to the keybinds menu.
Nested options no longer display the "new" icon, given that `Field`s can no longer be instantiated.
Gives all (non-abstract) options classes `__repr__()`s.
Made `Options.Value` (and `Options.Hidden` with it) inherit from `Generic[T]`.