### PR TITLE
ModMenu 2.3 fixes

### DIFF
--- a/Mods/BackpackManager/__init__.py
+++ b/Mods/BackpackManager/__init__.py
@@ -1,6 +1,6 @@
 import unrealsdk
-from Mods.ModMenu import EnabledSaveType, Mods, ModTypes, Options, RegisterMod, SDKMod, Hook
-from Mods import ModMenu
+
+from Mods.ModMenu import EnabledSaveType, Hook, ModTypes, Options, RegisterMod, SDKMod
 
 
 class BackpackManager(SDKMod):
@@ -12,30 +12,23 @@ class BackpackManager(SDKMod):
     Types: ModTypes = ModTypes.Gameplay
     SaveEnabledState: EnabledSaveType = EnabledSaveType.LoadWithSettings
 
-    BackpackSize: ModMenu.Options.Slider = Options.Slider(
+    BackpackSize: Options.Slider = Options.Slider(
         "Backpack", "Change the size of your character's backpack<br>Default is 39", 39, 0, 200, 1
     )
     Options = [BackpackSize]
 
     @Hook("WillowGame.WillowHUD.CreateWeaponScopeMovie")
-    def _GameLoad(caller: unrealsdk.UObject, function: unrealsdk.UFunction, params: unrealsdk.FStruct) -> bool:
+    def _GameLoad(self, caller: unrealsdk.UObject, function: unrealsdk.UFunction, params: unrealsdk.FStruct) -> bool:
         PC = unrealsdk.GetEngine().GamePlayers[0].Actor
         if PC and PC.Pawn:
-            PC.Pawn.InvManager.InventorySlotMax_Misc = _ModInstance.BackpackSize.CurrentValue
+            PC.Pawn.InvManager.InventorySlotMax_Misc = self.BackpackSize.CurrentValue
         return True
 
-    def Enable(self) -> None:
-        super().Enable()
-
-    def Disable(self) -> None:
-        ModMenu.RemoveHooks(self)
-
     def ModOptionChanged(self, option, newValue) -> None:
-        if option.Caption == "Backpack":
+        if option == self.BackpackSize:
             PC = unrealsdk.GetEngine().GamePlayers[0].Actor
             if PC and PC.Pawn:
                 PC.Pawn.InvManager.InventorySlotMax_Misc = newValue
 
 
-_ModInstance = BackpackManager()
-RegisterMod(_ModInstance)
+RegisterMod(BackpackManager())

--- a/Mods/ModMenu/HookManager.py
+++ b/Mods/ModMenu/HookManager.py
@@ -4,7 +4,7 @@ import unrealsdk
 import functools
 import weakref
 from inspect import Parameter, signature
-from typing import Any, Callable, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 __all__: Tuple[str, ...] = (
     "AnyHook",
@@ -16,8 +16,14 @@ __all__: Tuple[str, ...] = (
 )
 
 
-HookFunction = Callable[[unrealsdk.UObject, unrealsdk.UFunction, unrealsdk.FStruct], Any]
-HookMethod = Callable[[object, unrealsdk.UObject, unrealsdk.UFunction, unrealsdk.FStruct], Any]
+HookFunction = Callable[
+    [unrealsdk.UObject, unrealsdk.UFunction, unrealsdk.FStruct],
+    Optional[bool]
+]
+HookMethod = Callable[
+    [Any, unrealsdk.UObject, unrealsdk.UFunction, unrealsdk.FStruct],
+    Optional[bool]
+]
 AnyHook = Union[HookFunction, HookMethod]
 
 

--- a/Mods/ModMenu/KeybindManager.py
+++ b/Mods/ModMenu/KeybindManager.py
@@ -163,8 +163,12 @@ def _KeyboardMouseOptionsPopulate(caller: unrealsdk.UObject, function: unrealsdk
     for mod in ModObjects.Mods:
         if not mod.IsEnabled:
             continue
-        if len(mod.Keybinds) > 0:
+        for input in mod.Keybinds:
+            if isinstance(input, Keybind) and input.IsHidden:
+                continue
             disabled = False
+            break
+        if not disabled:
             break
 
     def AddListItem(caller: unrealsdk.UObject, function: unrealsdk.UFunction, params: unrealsdk.FStruct) -> bool:
@@ -209,7 +213,7 @@ def _extOnPopulateKeys(caller: unrealsdk.UObject, function: unrealsdk.UFunction,
         if not mod.IsEnabled:
             continue
 
-        if all(k.IsHidden for k in mod.Keybinds):
+        if all(isinstance(k, Keybind) and k.IsHidden for k in mod.Keybinds):
             continue
 
         tag = f"{_TAG_SEPERATOR}.{mod.Name}"

--- a/Mods/ModMenu/__init__.py
+++ b/Mods/ModMenu/__init__.py
@@ -37,7 +37,7 @@ __all__: Tuple[str, ...] = (
 
 # Need to define these up here so that they're accessable when importing the other files
 VERSION_MAJOR = 2
-VERSION_MINOR = 3
+VERSION_MINOR = 4
 
 unrealsdk.Log(f"[ModMenu] Version: {VERSION_MAJOR}.{VERSION_MINOR}")
 

--- a/Mods/SkillRandomizer/__init__.py
+++ b/Mods/SkillRandomizer/__init__.py
@@ -12,7 +12,7 @@ from Mods.ModMenu import Game, Hook
 class CrossSkillRandomizer(BL2MOD):
     Name: str = "Cross Class Skill Randomizer ({})"
     Description: str = "Randomize all the skills!"
-    Version: str = "1.1"
+    Version: str = "1.2"
     Author: str = "Abahbob"
     SupportedGames = Game.BL2
     LocalModDir: str = os.path.dirname(os.path.realpath(__file__))
@@ -38,7 +38,7 @@ class CrossSkillRandomizer(BL2MOD):
             unrealsdk.Mods.insert(0, NewRando)
 
     @Hook("WillowGame.PlayerSkillTree.Initialize")
-    def InjectSkills(caller: UObject, function: UFunction, params: FStruct) -> bool:
+    def InjectSkills(self, caller: UObject, function: UFunction, params: FStruct) -> bool:
         if not self.Seed:
             self.Seed = random.randrange(sys.maxsize)
             unrealsdk.Log("Randomizing with seed '{}'".format(self.Seed))


### PR DESCRIPTION
This PR fixes a few small issues encountered during the release of ModMenu v2.3

Currently:
- Fixed skill randomizer hook not working at all.
- Fixed that the modded keybinds menu could appear with no options if all enabled mods' keybinds were hidden.
- Fixed that the keybinds entry in the settings file could appear with no entries if all of a mod's keybinds were non-rebindable.
- Fixed a few cases where legacy list-style keybinds were mistakenly taken to be `Keybind` objects.