### PR TITLE
ReadOnly: Save enabled state

### DIFF
--- a/Mods/ReadOnly/__init__.py
+++ b/Mods/ReadOnly/__init__.py
@@ -1,5 +1,5 @@
 from unrealsdk import *
-from ..ModManager import BL2MOD, RegisterMod
+from ..ModManager import BL2MOD, RegisterMod, EnabledSaveType
 import math
 
 class ReadOnly(BL2MOD):
@@ -10,6 +10,7 @@ class ReadOnly(BL2MOD):
 
     DefaultGameInfo = UObject.FindObjectsContaining("WillowCoopGameInfo WillowGame.Default__WillowCoopGameInfo")[0]
     Keybinds = [["Toggle Read Only", "F2"]]
+    SaveEnabledState: EnabledSaveType = EnabledSaveType.LoadWithSettings
 
     def displayFeedback(self):
         PC = GetEngine().GamePlayers[0].Actor


### PR DESCRIPTION
In current version, Easy Read Only doesn’t set `SaveEnabledState` so you have to enable it manually every launch.

I thought it’s important to fix that because someone could have enabled it and on next sessions assume it’s enabled, do a mission, save and quit, press the keybind, accept the mission reward, save and quit and expect it to have not modified their save. Granted, when the mod is enabled pressing the keybind shows a message on the screen so it is less likely to happen I suppose.