### PR TITLE
Support static array properties

### DIFF
--- a/src/CHookManager.cpp
+++ b/src/CHookManager.cpp
@@ -96,7 +96,8 @@ bool CHookManager::ProcessHooks(UObject* Caller, FFrame& Stack, void* const Resu
 			}
 			UnrealSDK::pFrameStep(&Stack, Stack.Object, Frame + Property->Offset_Internal);
 		}
-		const bool ret = ProcessHooks(Function->GetObjectName(), Caller, Function, &FStruct{Function, (void *)Frame});
+		auto FrameStruct = FStruct{ Function, (void*) Frame };
+		const bool ret = ProcessHooks(Function->GetObjectName(), Caller, Function, &FrameStruct);
 		//if (!ret) {
 		//	if (ReturnParm)
 		//	{

--- a/src/CPythonInterface.cpp
+++ b/src/CPythonInterface.cpp
@@ -134,8 +134,12 @@ void AddToConsoleLog(UConsole* console, FString input)
 
 bool CheckPythonCommand(UObject* caller, UFunction* function, FStruct* params)
 {
-	FString* command = ((FHelper *)params->base)->GetStrProperty(
-		(UProperty *)params->structType->FindChildByName(FName("command")));
+	FString* command = reinterpret_cast<FString*>(
+		((FHelper *)params->base)->GetPropertyAddress(
+			(UProperty *)params->structType->FindChildByName(FName("command")),
+			0
+		)
+	);
 	char* input = command->AsString();
 	if (strncmp("py ", input, 3) == 0)
 	{

--- a/src/CPythonInterface.cpp
+++ b/src/CPythonInterface.cpp
@@ -135,11 +135,9 @@ void AddToConsoleLog(UConsole* console, FString input)
 
 bool CheckPythonCommand(UObject* caller, UFunction* function, FStruct* params)
 {
-	FString* command = reinterpret_cast<FString*>(
-		((FHelper *)params->base)->GetPropertyAddress(
-			(UProperty *)params->structType->FindChildByName(FName("command")),
-			0
-		)
+	FString* command = ((FHelper*)params->base)->GetStrProperty(
+		(UProperty*)params->structType->FindChildByName(FName("command")),
+		0
 	);
 	char* input = command->AsString();
 	if (strncmp("py ", input, 3) == 0)

--- a/src/CPythonInterface.cpp
+++ b/src/CPythonInterface.cpp
@@ -71,7 +71,8 @@ PYBIND11_EMBEDDED_MODULE(unrealsdk, m)
 	m.def("LoadPackage", &UnrealSDK::LoadPackage, py::arg("filename"), py::arg("flags") = 0, py::arg("force") = false);
 	m.def("KeepAlive", &UnrealSDK::KeepAlive);
 	m.def("GetPackageObject", &UObject::GetPackageObject, py::return_value_policy::reference);
-	m.def("FindAll", &UObject::FindAll, py::return_value_policy::reference);
+	m.def("FindAll", &UObject::FindAll, py::arg("InStr"), py::arg("IncludeSubclasses") = false,
+		  py::return_value_policy::reference);
 	m.def("FindClass", &UObject::FindClass, py::arg("ClassName"), py::arg("Lookup") = false,
 	      py::return_value_policy::reference);
 	m.def("FindObject", [](char* ClassName, char* ObjectFullName) { return UObject::Find(ClassName, ObjectFullName); },

--- a/src/CoreExtensions.cpp
+++ b/src/CoreExtensions.cpp
@@ -335,7 +335,7 @@ void FHelper::SetDelegateProperty(class UProperty* Prop, int idx, const py::obje
 
 void FHelper::SetFloatProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
-	if (!py::isinstance<py::float_>(Val))
+	if (!py::isinstance<py::float_>(Val) && !py::isinstance<py::int_>(Val))
 		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected float!");
 
 	reinterpret_cast<float*>(GetPropertyAddress(Prop, idx))[0] = Val.cast<float>();
@@ -368,9 +368,9 @@ void FHelper::SetBoolProperty(class UProperty* Prop, int idx, const py::object& 
 		Logging::LogD("SetBoolProperty %d, mask: 0x%x, base: 0x%x, offset: 0x%x\n", Val.cast<bool>(), static_cast<UBoolProperty*>(Prop)->GetMask(),
 		              this, Prop->Offset_Internal);
 		if (Val.cast<bool>())
-			reinterpret_cast<unsigned int*>(GetPropertyAddress(Prop, idx))[0] |= static_cast<UBoolProperty*>(Prop)->GetMask();
+			reinterpret_cast<unsigned int*>(GetPropertyAddress(Prop, 0))[0] |= static_cast<UBoolProperty*>(Prop)->GetMask();
 		else
-			reinterpret_cast<unsigned int*>(GetPropertyAddress(Prop, idx))[0] &= ~static_cast<UBoolProperty*>(Prop)->GetMask();
+			reinterpret_cast<unsigned int*>(GetPropertyAddress(Prop, 0))[0] &= ~static_cast<UBoolProperty*>(Prop)->GetMask();
 	}
 	catch (std::exception e)
 	{
@@ -467,10 +467,10 @@ void FHelper::SetProperty(class UProperty* Prop, const py::object& Val)
 		));
 	}
 
-	for (auto i = 0; i < size; i++) {
+	for (size_t i = 0; i < size; i++) {
 		(this->*setter)(Prop, i, seq[i]);
 	}
-	for (auto i = size; i < (size_t)Prop->ArrayDim; i++) {
+	for (size_t i = size; i < (size_t)Prop->ArrayDim; i++) {
 		(this->*setter)(Prop, i, py::none());
 	}
 }

--- a/src/CoreExtensions.cpp
+++ b/src/CoreExtensions.cpp
@@ -279,7 +279,8 @@ void FHelper::SetStrProperty(class UProperty* Prop, int idx, const py::object& V
 	if (!py::isinstance<py::str>(Val))
 		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected string!");
 
-	memcpy(GetPropertyAddress(Prop, idx), &FString(Val.cast<std::wstring>().c_str()), sizeof(FString));
+	auto str = FString(Val.cast<std::wstring>().c_str());
+	memcpy(GetPropertyAddress(Prop, idx), &str, sizeof(FString));
 }
 
 void FHelper::SetObjectProperty(class UProperty* Prop, int idx, const py::object& Val)
@@ -311,7 +312,8 @@ void FHelper::SetNameProperty(class UProperty* Prop, int idx,  const py::object&
 	if (!py::isinstance<py::str>(Val))
 		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected string!");
 
-	memcpy(GetPropertyAddress(Prop, idx), &FName(Val.cast<std::string>().c_str()), sizeof(FName));
+	auto name = FName(Val.cast<std::string>().c_str());
+	memcpy(GetPropertyAddress(Prop, idx), &name, sizeof(FName));
 }
 
 void FHelper::SetInterfaceProperty(class UProperty* Prop, int idx, const py::object& Val)
@@ -334,9 +336,10 @@ void FHelper::SetDelegateProperty(class UProperty* Prop, int idx, const py::obje
 	if (!py::isinstance<FScriptDelegate>(Val))
 		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected FScriptDelegate!");
 
+	auto ScriptDelegate = FScriptDelegate(Val.cast<FScriptDelegate>());
 	memcpy(
 		GetPropertyAddress(Prop, idx),
-		&FScriptDelegate(Val.cast<FScriptDelegate>()),
+		&ScriptDelegate,
 	    sizeof(FScriptDelegate)
 	);
 }

--- a/src/CoreExtensions.cpp
+++ b/src/CoreExtensions.cpp
@@ -86,7 +86,7 @@ UClass* UObject::StaticClass()
 	return ptr;
 };
 
-std::vector<UObject*> UObject::FindAll(char* InStr)
+std::vector<UObject*> UObject::FindAll(char* InStr, bool IncludeSubclasses = false)
 {
 	UClass* inClass = FindClass(InStr, true);
 	if (!inClass)
@@ -95,8 +95,17 @@ std::vector<UObject*> UObject::FindAll(char* InStr)
 	for (size_t i = 0; i < GObjects()->Count; ++i)
 	{
 		UObject* object = GObjects()->Data[i];
-		if (object && object->Class == inClass)
-			ret.push_back(object);
+		if (!object || !object->Class) {
+			continue;
+		}
+		UClass* cls = object->Class;
+		do {
+			if (cls == inClass) {
+				ret.push_back(object);
+				break;
+			}
+			cls = static_cast<UClass*>(cls->SuperField);
+		} while (IncludeSubclasses && cls);
 	}
 	return ret;
 }

--- a/src/CoreExtensions.cpp
+++ b/src/CoreExtensions.cpp
@@ -101,120 +101,151 @@ std::vector<UObject*> UObject::FindAll(char* InStr)
 	return ret;
 }
 
-void* FHelper::GetPropertyAddress(UProperty* Prop)
+void* FHelper::GetPropertyAddress(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<char*>(this) + Prop->Offset_Internal;
+	return reinterpret_cast<char*>(this) + Prop->Offset_Internal + (idx * Prop->ElementSize);
 }
 
 
-struct FStruct FHelper::GetStructProperty(UStructProperty* Prop)
+py::object FHelper::GetStructProperty(UProperty* Prop, int idx)
 {
-	return FStruct{Prop->GetStruct(), GetPropertyAddress(Prop)};
+	return pybind11::cast(FStruct{
+		static_cast<UStructProperty*>(Prop)->GetStruct(),
+		GetPropertyAddress(Prop, idx)
+	});
 }
 
-struct FString* FHelper::GetStrProperty(UProperty* Prop)
+py::object FHelper::GetStrProperty(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<FString*>(GetPropertyAddress(Prop));
+	return py::cast(reinterpret_cast<FString*>(GetPropertyAddress(Prop, idx)));
 }
 
-class UObject* FHelper::GetObjectProperty(UProperty* Prop)
+py::object FHelper::GetObjectProperty(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<UObject **>(GetPropertyAddress(Prop))[0];
+	return py::cast(reinterpret_cast<UObject **>(GetPropertyAddress(Prop, idx))[0]);
 }
 
-class UComponent* FHelper::GetComponentProperty(UProperty* Prop)
+py::object FHelper::GetComponentProperty(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<UComponent **>(GetPropertyAddress(Prop))[0];
+	return py::cast(reinterpret_cast<UComponent **>(GetPropertyAddress(Prop, idx))[0]);
 }
 
-class UClass* FHelper::GetClassProperty(UProperty* Prop)
+py::object FHelper::GetClassProperty(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<UClass **>(GetPropertyAddress(Prop))[0];
+	return py::cast(reinterpret_cast<UClass **>(GetPropertyAddress(Prop, idx))[0]);
 }
 
-struct FName* FHelper::GetNameProperty(UProperty* Prop)
+py::object FHelper::GetNameProperty(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<FName*>(GetPropertyAddress(Prop));
+	return py::cast(reinterpret_cast<FName*>(GetPropertyAddress(Prop, idx)));
 }
 
-int FHelper::GetIntProperty(UProperty* Prop)
+py::object FHelper::GetInterfaceProperty(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<int*>(GetPropertyAddress(Prop))[0];
+	return py::cast(reinterpret_cast<FScriptInterface*>(GetPropertyAddress(Prop, idx)));
 }
 
-struct FScriptInterface* FHelper::GetInterfaceProperty(UProperty* Prop)
+py::object FHelper::GetDelegateProperty(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<FScriptInterface*>(GetPropertyAddress(Prop));
+	return py::cast(reinterpret_cast<FScriptDelegate*>(GetPropertyAddress(Prop, idx)));
 }
 
-float FHelper::GetFloatProperty(UProperty* Prop)
+py::object FHelper::GetFloatProperty(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<float*>(GetPropertyAddress(Prop))[0];
+	return py::cast(reinterpret_cast<float*>(GetPropertyAddress(Prop, idx))[0]);
 }
 
-struct FScriptDelegate* FHelper::GetDelegateProperty(UProperty* Prop)
-{
-	return reinterpret_cast<FScriptDelegate*>(GetPropertyAddress(Prop));
+py::object FHelper::GetIntProperty(UProperty* Prop, int idx) {
+	return py::cast(reinterpret_cast<int*>(GetPropertyAddress(Prop, idx))[0]);
 }
 
-unsigned char FHelper::GetByteProperty(UProperty* Prop)
+py::object FHelper::GetByteProperty(UProperty* Prop, int idx)
 {
-	return reinterpret_cast<unsigned char*>(GetPropertyAddress(Prop))[0];
+	return py::cast(reinterpret_cast<unsigned char*>(GetPropertyAddress(Prop, idx))[0]);
 }
 
-bool FHelper::GetBoolProperty(UBoolProperty* Prop)
+py::object FHelper::GetBoolProperty(UProperty* Prop, int idx)
 {
-	return !!(GetIntProperty(Prop) & Prop->GetMask());
+	if (idx != 0) {
+		// Pretty sure this is a requirement of the engine, so we'll never actually run into it
+		throw py::index_error("FHelper::SetProperty: Bool arrays are not supported");
+	}
+	return py::cast(
+		!!(GetIntProperty(Prop, 0).cast<int>() & static_cast<UBoolProperty*>(Prop)->GetMask())
+	);
 }
 
-py::object FHelper::GetArrayProperty(UArrayProperty* Prop)
+py::object FHelper::GetArrayProperty(UProperty* Prop, int idx)
 {
-	const auto array = reinterpret_cast<TArray<char>*>(GetPropertyAddress(Prop));
-	return pybind11::cast(FArray{ array, Prop->GetInner()});
+	const auto array = reinterpret_cast<TArray<char>*>(GetPropertyAddress(Prop, idx));
+	return py::cast(FArray{ array, static_cast<UArrayProperty*>(Prop)->GetInner()});
 }
 
-pybind11::object FHelper::GetProperty(UProperty* Prop)
+py::object FHelper::GetProperty(UProperty* Prop)
 {
-	Logging::LogD("FHelper::GetProperty '%s' (offset 0x%x) (Prop at 0x%p) on 0x%p\n", Prop->GetFullName().c_str(),
-	              Prop->Offset_Internal, Prop, this);
+	Logging::LogD(
+		"FHelper::GetProperty '%s' (offset 0x%x, arraydim %d) (Prop at 0x%p) on 0x%p\n",
+		Prop->GetFullName().c_str(),
+	    Prop->Offset_Internal,
+		Prop->ArrayDim,
+		Prop,
+		this
+	);
+
+	py::object (FHelper::*getter)(UProperty*, int);
+
 	if (!strcmp(Prop->Class->GetName(), "StructProperty"))
-		return pybind11::cast(GetStructProperty(static_cast<UStructProperty*>(Prop)));
-	if (!strcmp(Prop->Class->GetName(), "StrProperty"))
-		return pybind11::cast(GetStrProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "ObjectProperty"))
-		return pybind11::cast(GetObjectProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "ComponentProperty"))
-		return pybind11::cast(GetComponentProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "ClassProperty"))
-		return pybind11::cast(GetClassProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "NameProperty"))
-		return pybind11::cast(GetNameProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "IntProperty"))
-		return pybind11::cast(GetIntProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "InterfaceProperty"))
-		return pybind11::cast(GetInterfaceProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "FloatProperty"))
-		return pybind11::cast(GetFloatProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "DelegateProperty"))
-		return pybind11::cast(GetDelegateProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "ByteProperty"))
-		return pybind11::cast(GetByteProperty(Prop));
-	if (!strcmp(Prop->Class->GetName(), "BoolProperty"))
-		return pybind11::cast(GetBoolProperty(static_cast<UBoolProperty*>(Prop)));
-	if (!strcmp(Prop->Class->GetName(), "ArrayProperty"))
-		return GetArrayProperty(static_cast<UArrayProperty*>(Prop));
-	throw std::exception(Util::Format("FHelper::GetProperty got unexpected property type '%s'",
-	                                  Prop->GetFullName().c_str()).c_str());
+		getter = &FHelper::GetStructProperty;
+	else if (!strcmp(Prop->Class->GetName(), "StrProperty"))
+		getter = &FHelper::GetStrProperty;
+	else if (!strcmp(Prop->Class->GetName(), "ObjectProperty"))
+		getter = &FHelper::GetObjectProperty;
+	else if (!strcmp(Prop->Class->GetName(), "ComponentProperty"))
+		getter = &FHelper::GetComponentProperty;
+	else if (!strcmp(Prop->Class->GetName(), "ClassProperty"))
+		getter = &FHelper::GetClassProperty;
+	else if (!strcmp(Prop->Class->GetName(), "NameProperty"))
+		getter = &FHelper::GetNameProperty;
+	else if (!strcmp(Prop->Class->GetName(), "InterfaceProperty"))
+		getter = &FHelper::GetInterfaceProperty;
+	else if (!strcmp(Prop->Class->GetName(), "DelegateProperty"))
+		getter = &FHelper::GetDelegateProperty;
+	else if (!strcmp(Prop->Class->GetName(), "FloatProperty"))
+		getter = &FHelper::GetFloatProperty;
+	else if (!strcmp(Prop->Class->GetName(), "IntProperty"))
+		getter = &FHelper::GetIntProperty;
+	else if (!strcmp(Prop->Class->GetName(), "ByteProperty"))
+		getter = &FHelper::GetByteProperty;
+	else if (!strcmp(Prop->Class->GetName(), "BoolProperty"))
+		getter = &FHelper::GetBoolProperty;
+	else if (!strcmp(Prop->Class->GetName(), "ArrayProperty"))
+		getter = &FHelper::GetArrayProperty;
+	else
+		throw std::runtime_error(Util::Format(
+			"FHelper::GetProperty got unexpected property type '%s'",
+			Prop->GetFullName().c_str()
+		).c_str());
+
+	if (Prop->ArrayDim == 1) {
+		return (this->*getter)(Prop, 0);
+	}
+
+	auto list = pybind11::list();
+	for (int i = 0; i < Prop->ArrayDim; i++) {
+		list.append((this->*getter)(Prop, i));
+	}
+
+	return list;
 }
 
-void FHelper::SetProperty(class UStructProperty* Prop, const py::object& Val)
+void FHelper::SetStructProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (py::isinstance<py::tuple>(Val))
 	{
 		const py::tuple tup = static_cast<py::tuple>(Val);
 
 		unsigned int currentIndex = 0;
-		for (auto* child = static_cast<UProperty*>(Prop->GetStruct()->Children); child; child = static_cast<UProperty*>(child->Next))
+		for (auto* child = static_cast<UProperty*>(static_cast<UStructProperty*>(Prop)->GetStruct()->Children); child; child = static_cast<UProperty*>(child->Next))
 			currentIndex++;
 
 		if (tup.size() > currentIndex)
@@ -224,104 +255,122 @@ void FHelper::SetProperty(class UStructProperty* Prop, const py::object& Val)
 		}
 
 		currentIndex = 0;
-		for (auto* child = static_cast<UProperty*>(Prop->GetStruct()->Children); child; child = static_cast<UProperty*>(child->Next))
+		for (auto* child = static_cast<UProperty*>(static_cast<UStructProperty*>(Prop)->GetStruct()->Children); child; child = static_cast<UProperty*>(child->Next))
 		{
 			Logging::LogD("Child = %s, %d\n", child->GetFullName().c_str(), child->Offset_Internal);
 			if (currentIndex < tup.size())
-				reinterpret_cast<FHelper*>(GetPropertyAddress(Prop))->SetProperty(child, tup[currentIndex++]);
+				reinterpret_cast<FHelper*>(GetPropertyAddress(Prop, idx))->SetProperty(child, tup[currentIndex++]);
 		}
 	}
 	else
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected tuple!\n").c_str());
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected tuple!");
 }
 
-void FHelper::SetProperty(class UStrProperty* Prop, const py::object& Val)
+void FHelper::SetStrProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (!py::isinstance<py::str>(Val))
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected string!\n").c_str());
-	memcpy(GetPropertyAddress(Prop), &FString(Val.cast<std::wstring>().c_str()), sizeof(FString));
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected string!");
+
+	memcpy(GetPropertyAddress(Prop, idx), &FString(Val.cast<std::wstring>().c_str()), sizeof(FString));
 }
 
-void FHelper::SetProperty(class UObjectProperty* Prop, const py::object& Val)
+void FHelper::SetObjectProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (!py::isinstance<UObject>(Val) && !py::isinstance<py::none>(Val))
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected UObject!\n").c_str());
-	reinterpret_cast<UObject **>(GetPropertyAddress(Prop))[0] = Val.cast<UObject*>();
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected UObject!");
+
+	reinterpret_cast<UObject **>(GetPropertyAddress(Prop, idx))[0] = Val.cast<UObject*>();
 }
 
-void FHelper::SetProperty(class UComponentProperty* Prop, const py::object& Val)
+void FHelper::SetComponentProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (!py::isinstance<UComponent>(Val) && !py::isinstance<py::none>(Val))
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected UComponent!\n").c_str());
-	reinterpret_cast<UComponent * *>(GetPropertyAddress(Prop))[0] = Val.cast<UComponent*>();
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected UComponent!");
+
+	reinterpret_cast<UComponent **>(GetPropertyAddress(Prop, idx))[0] = Val.cast<UComponent*>();
 }
 
-void FHelper::SetProperty(class UClassProperty* Prop, const py::object& Val)
+void FHelper::SetClassProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (!py::isinstance<UClass>(Val) && !py::isinstance<py::none>(Val))
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected UClass!\n").c_str());
-	reinterpret_cast<UClass * *>(GetPropertyAddress(Prop))[0] = Val.cast<UClass*>();
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected UClass!");
+
+	reinterpret_cast<UClass * *>(GetPropertyAddress(Prop, idx))[0] = Val.cast<UClass*>();
 }
 
-void FHelper::SetProperty(class UNameProperty* Prop, const py::object& Val)
+void FHelper::SetNameProperty(class UProperty* Prop, int idx,  const py::object& Val)
 {
 	if (!py::isinstance<py::str>(Val))
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected string!\n").c_str());
-	memcpy(GetPropertyAddress(Prop), &FName(Val.cast<std::string>().c_str()), sizeof(FName));
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected string!");
+
+	memcpy(GetPropertyAddress(Prop, idx), &FName(Val.cast<std::string>().c_str()), sizeof(FName));
 }
 
-void FHelper::SetProperty(class UInterfaceProperty* Prop, const py::object& Val)
+void FHelper::SetInterfaceProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (!py::isinstance<UObject>(Val) && !py::isinstance<py::none>(Val))
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected UObject!\n").c_str());
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected UObject!");
+
 	if (py::isinstance<py::none>(Val))
-		static_cast<FScriptInterface*>(GetPropertyAddress(Prop))[0] = FScriptInterface{nullptr, nullptr};
+		static_cast<FScriptInterface*>(GetPropertyAddress(Prop, idx))[0] = FScriptInterface{nullptr, nullptr};
 	else
 	{
 		const auto objVal = Val.cast<UObject*>();
-		const auto scriptInterface = objVal->QueryInterface(Prop->GetInterfaceClass());
-		reinterpret_cast<FScriptInterface*>(GetPropertyAddress(Prop))[0] = scriptInterface;
+		const auto scriptInterface = objVal->QueryInterface(static_cast<UInterfaceProperty*>(Prop)->GetInterfaceClass());
+		reinterpret_cast<FScriptInterface*>(GetPropertyAddress(Prop, idx))[0] = scriptInterface;
 	}
 }
 
-void FHelper::SetProperty(class UDelegateProperty* Prop, const py::object& Val)
+void FHelper::SetDelegateProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (!py::isinstance<FScriptDelegate>(Val))
-		throw std::exception(
-			Util::Format("FHelper::SetProperty: Got unexpected type, expected FScriptDelegate!\n").c_str());
-	memcpy(GetPropertyAddress(Prop), &FScriptDelegate(Val.cast<FScriptDelegate>()),
-	       sizeof(FScriptDelegate));
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected FScriptDelegate!");
+
+	memcpy(
+		GetPropertyAddress(Prop, idx),
+		&FScriptDelegate(Val.cast<FScriptDelegate>()),
+	    sizeof(FScriptDelegate)
+	);
 }
 
-void FHelper::SetProperty(class UFloatProperty* Prop, const py::object& Val)
+void FHelper::SetFloatProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
-	reinterpret_cast<float*>(GetPropertyAddress(Prop))[0] = Val.cast<float>();
+	if (!py::isinstance<py::float_>(Val))
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected float!");
+
+	reinterpret_cast<float*>(GetPropertyAddress(Prop, idx))[0] = Val.cast<float>();
 }
 
-void FHelper::SetProperty(class UIntProperty* Prop, const py::object& Val)
+void FHelper::SetIntProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (!py::isinstance<py::int_>(Val))
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected int!\n").c_str());
-	reinterpret_cast<int*>(GetPropertyAddress(Prop))[0] = Val.cast<int>();
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected int!");
+
+	reinterpret_cast<int*>(GetPropertyAddress(Prop, idx))[0] = Val.cast<int>();
 }
 
-void FHelper::SetProperty(class UByteProperty* Prop, const py::object& Val)
+void FHelper::SetByteProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (!py::isinstance<py::int_>(Val))
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected (char!\n").c_str());
-	reinterpret_cast<char*>(GetPropertyAddress(Prop))[0] = static_cast<char>(Val.cast<int>());
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected int!");
+
+	reinterpret_cast<char*>(GetPropertyAddress(Prop, idx))[0] = static_cast<char>(Val.cast<int>());
 }
 
-void FHelper::SetProperty(class UBoolProperty* Prop, const py::object& Val)
+void FHelper::SetBoolProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
+	if (idx != 0) {
+		throw py::index_error("FHelper::SetProperty: Bool arrays are not supported");
+	}
+
 	try
 	{
-		Logging::LogD("SetBoolProperty %d, mask: 0x%x, base: 0x%x, offset: 0x%x\n", Val.cast<bool>(), Prop->GetMask(),
+		Logging::LogD("SetBoolProperty %d, mask: 0x%x, base: 0x%x, offset: 0x%x\n", Val.cast<bool>(), static_cast<UBoolProperty*>(Prop)->GetMask(),
 		              this, Prop->Offset_Internal);
 		if (Val.cast<bool>())
-			reinterpret_cast<unsigned int*>(GetPropertyAddress(Prop))[0] |= Prop->GetMask();
+			reinterpret_cast<unsigned int*>(GetPropertyAddress(Prop, idx))[0] |= static_cast<UBoolProperty*>(Prop)->GetMask();
 		else
-			reinterpret_cast<unsigned int*>(GetPropertyAddress(Prop))[0] &= ~Prop->GetMask();
+			reinterpret_cast<unsigned int*>(GetPropertyAddress(Prop, idx))[0] &= ~static_cast<UBoolProperty*>(Prop)->GetMask();
 	}
 	catch (std::exception e)
 	{
@@ -329,17 +378,18 @@ void FHelper::SetProperty(class UBoolProperty* Prop, const py::object& Val)
 	}
 }
 
-void FHelper::SetProperty(class UArrayProperty* Prop, const py::object& Val)
+void FHelper::SetArrayProperty(class UProperty* Prop, int idx, const py::object& Val)
 {
 	if (!py::isinstance<py::sequence>(Val))
-		throw std::exception(Util::Format("FHelper::SetProperty: Got unexpected type, expected list!\n").c_str());
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected sequence!");
+
 	const auto s = py::reinterpret_borrow<py::sequence>(Val);
-	const auto currentArray = reinterpret_cast<TArray<char>*>(GetPropertyAddress(Prop));
+	const auto currentArray = reinterpret_cast<TArray<char>*>(GetPropertyAddress(Prop, idx));
 	if (s.size() > currentArray->Count)
 	{
 		char *data = static_cast<char*>(static_cast<tMalloc>(UnrealSDK::pGMalloc[0][0][1])(UnrealSDK::pGMalloc[0],
-		                                                                           Prop->GetInner()->ElementSize * s.size(), 8));
-		memset(data, 0, Prop->GetInner()->ElementSize * s.size());
+		                                                                           static_cast<UArrayProperty*>(Prop)->GetInner()->ElementSize * s.size(), 8));
+		memset(data, 0, static_cast<UArrayProperty*>(Prop)->GetInner()->ElementSize * s.size());
 		currentArray->Data = data;
 		currentArray->Max = s.size();
 	}
@@ -347,43 +397,82 @@ void FHelper::SetProperty(class UArrayProperty* Prop, const py::object& Val)
 	int x = 0;
 	for (const auto it : Val)
 	{
-		reinterpret_cast<FHelper*>(currentArray->Data + Prop->GetInner()->ElementSize * x++)->SetProperty(
-			Prop->GetInner(), py::reinterpret_borrow<py::object>(it));
+		reinterpret_cast<FHelper*>(currentArray->Data + static_cast<UArrayProperty*>(Prop)->GetInner()->ElementSize * x++)->SetProperty(
+			static_cast<UArrayProperty*>(Prop)->GetInner(), py::reinterpret_borrow<py::object>(it));
 	}
 }
 
-void FHelper::SetProperty(class UProperty* Prop, const py::object& val)
+void FHelper::SetProperty(class UProperty* Prop, const py::object& Val)
 {
-	Logging::LogD("FHelper::SetProperty Called with '%s'\n", Prop->GetFullName().c_str());
+	Logging::LogD(
+		"FHelper::SetProperty '%s' (offset 0x%x, arraydim %d) (Prop at 0x%p) on 0x%p\n",
+		Prop->GetFullName().c_str(),
+		Prop->Offset_Internal,
+		Prop->ArrayDim,
+		Prop,
+		this
+	);
+
+	void (FHelper::*setter)(UProperty*, int, const py::object&);
+
 	if (!strcmp(Prop->Class->GetName(), "StructProperty"))
-		SetProperty(static_cast<UStructProperty*>(Prop), val);
+		setter = &FHelper::SetStructProperty;
 	else if (!strcmp(Prop->Class->GetName(), "StrProperty"))
-		SetProperty(static_cast<UStrProperty*>(Prop), val);
+		setter = &FHelper::SetStrProperty;
 	else if (!strcmp(Prop->Class->GetName(), "ObjectProperty"))
-		SetProperty(static_cast<UObjectProperty*>(Prop), val);
+		setter = &FHelper::SetObjectProperty;
 	else if (!strcmp(Prop->Class->GetName(), "ComponentProperty"))
-		SetProperty(static_cast<UComponentProperty*>(Prop), val);
+		setter = &FHelper::SetComponentProperty;
 	else if (!strcmp(Prop->Class->GetName(), "ClassProperty"))
-		SetProperty(static_cast<UClassProperty*>(Prop), val);
+		setter = &FHelper::SetClassProperty;
 	else if (!strcmp(Prop->Class->GetName(), "NameProperty"))
-		SetProperty(static_cast<UNameProperty*>(Prop), val);
-	else if (!strcmp(Prop->Class->GetName(), "IntProperty"))
-		SetProperty(static_cast<UIntProperty*>(Prop), val);
+		setter = &FHelper::SetNameProperty;
 	else if (!strcmp(Prop->Class->GetName(), "InterfaceProperty"))
-		SetProperty(static_cast<UInterfaceProperty*>(Prop), val);
-	else if (!strcmp(Prop->Class->GetName(), "FloatProperty"))
-		SetProperty(static_cast<UFloatProperty*>(Prop), val);
+		setter = &FHelper::SetInterfaceProperty;
 	else if (!strcmp(Prop->Class->GetName(), "DelegateProperty"))
-		SetProperty(static_cast<UDelegateProperty*>(Prop), val);
+		setter = &FHelper::SetDelegateProperty;
+	else if (!strcmp(Prop->Class->GetName(), "FloatProperty"))
+		setter = &FHelper::SetFloatProperty;
+	else if (!strcmp(Prop->Class->GetName(), "IntProperty"))
+		setter = &FHelper::SetIntProperty;
 	else if (!strcmp(Prop->Class->GetName(), "ByteProperty"))
-		SetProperty(static_cast<UByteProperty*>(Prop), val);
+		setter = &FHelper::SetByteProperty;
 	else if (!strcmp(Prop->Class->GetName(), "BoolProperty"))
-		SetProperty(static_cast<UBoolProperty*>(Prop), val);
+		setter = &FHelper::SetBoolProperty;
 	else if (!strcmp(Prop->Class->GetName(), "ArrayProperty"))
-		SetProperty(static_cast<UArrayProperty*>(Prop), val);
+		setter = &FHelper::SetArrayProperty;
 	else
-		throw std::exception(Util::Format("FHelper::SetProperty got unexpected property type '%s'",
-		                                  Prop->GetFullName().c_str()).c_str());
+		throw std::runtime_error(Util::Format(
+			"FHelper::SetProperty got unexpected property type '%s'",
+			Prop->GetFullName().c_str()
+		).c_str());
+
+	if (Prop->ArrayDim == 1) {
+		(this->*setter)(Prop, 0, Val);
+		return;
+	}
+
+	if (!py::isinstance<py::sequence>(Val)) {
+		throw py::type_error("FHelper::SetProperty: Got unexpected type, expected sequence!");
+	}
+
+	auto seq = py::reinterpret_borrow<py::sequence>(Val);
+	auto size = seq.size();
+
+	if (size > (size_t)Prop->ArrayDim) {
+		throw py::type_error(Util::Format(
+			"FHelper::SetProperty: Sequence is too long, %s supports max of %d values!",
+			Prop->GetName(),
+			Prop->ArrayDim
+		));
+	}
+
+	for (auto i = 0; i < size; i++) {
+		(this->*setter)(Prop, i, seq[i]);
+	}
+	for (auto i = size; i < (size_t)Prop->ArrayDim; i++) {
+		(this->*setter)(Prop, i, py::none());
+	}
 }
 
 TArray<UObject*>* UObject::GObjects()

--- a/src/UnrealSDK.cpp
+++ b/src/UnrealSDK.cpp
@@ -71,8 +71,9 @@ namespace UnrealSDK
 			              callerName.c_str(), functionName.c_str());
 		}
 
+		auto ParamsStruct = FStruct{Function, Params};
 		if (gHookManager->HasHook(caller, Function) && !gHookManager->ProcessHooks(
-			functionName, caller, Function, &FStruct{Function, Params}))
+			functionName, caller, Function, &ParamsStruct))
 		{
 			// The engine hook manager told us not to pass this function to the engine
 			return;

--- a/src/include/UnrealEngine/Core/Core_classes.h
+++ b/src/include/UnrealEngine/Core/Core_classes.h
@@ -183,19 +183,19 @@ struct FHelper {
 	py::object GetProperty(class UProperty* Prop);
 	void SetProperty(class UProperty* Prop, const py::object& Val);
 
-	py::object GetStructProperty(class UProperty *Prop, int idx);
-	py::object GetStrProperty(class UProperty *Prop, int idx);
-	py::object GetObjectProperty(class UProperty *Prop, int idx);
-	py::object GetComponentProperty(class UProperty *Prop, int idx);
-	py::object GetClassProperty(class UProperty *Prop, int idx);
-	py::object GetNameProperty(class UProperty *Prop, int idx);
-	py::object GetInterfaceProperty(class UProperty *Prop, int idx);
-	py::object GetDelegateProperty(class UProperty *Prop, int idx);
-	py::object GetFloatProperty(class UProperty *Prop, int idx);
-	py::object GetIntProperty(class UProperty *Prop, int idx);
-	py::object GetByteProperty(class UProperty *Prop, int idx);
-	py::object GetBoolProperty(class UProperty *Prop, int idx);
-	py::object GetArrayProperty(class UProperty *Prop, int idx);
+	struct FStruct GetStructProperty(class UProperty *Prop, int idx);
+	struct FString* GetStrProperty(class UProperty *Prop, int idx);
+	class UObject* GetObjectProperty(class UProperty *Prop, int idx);
+	class UComponent* GetComponentProperty(class UProperty *Prop, int idx);
+	class UClass* GetClassProperty(class UProperty *Prop, int idx);
+	struct FName* GetNameProperty(class UProperty *Prop, int idx);
+	struct FScriptInterface* GetInterfaceProperty(class UProperty *Prop, int idx);
+	struct FScriptDelegate* GetDelegateProperty(class UProperty *Prop, int idx);
+	float GetFloatProperty(class UProperty *Prop, int idx);
+	int GetIntProperty(class UProperty *Prop, int idx);
+	unsigned char GetByteProperty(class UProperty *Prop, int idx);
+	bool GetBoolProperty(class UProperty *Prop, int idx);
+	struct FArray GetArrayProperty(class UProperty *Prop, int idx);
 
 	void SetStructProperty(class UProperty* Prop, int idx, const py::object& Val);
 	void SetStrProperty(class UProperty* Prop, int idx, const py::object& Val);
@@ -1290,7 +1290,7 @@ struct FFunction
 	UFunction *func;
 
 private:
-	FHelper* GenerateParams(const py::args& args, const py::kwargs& kwargs, FHelper* params);
+	void GenerateParams(const py::args& args, const py::kwargs& kwargs, FHelper* params);
 
 public:
 	py::object GetReturn(FHelper* params);

--- a/src/include/UnrealEngine/Core/Core_classes.h
+++ b/src/include/UnrealEngine/Core/Core_classes.h
@@ -179,36 +179,37 @@
 */
 
 struct FHelper {
-	struct FStruct GetStructProperty(class UStructProperty *Prop);
-	struct FString* GetStrProperty(class UProperty *Prop);
-	class UObject* GetObjectProperty(class UProperty *Prop);
-	class UComponent* GetComponentProperty(class UProperty *Prop);
-	class UClass* GetClassProperty(class UProperty *Prop);
-	struct FName* GetNameProperty(class UProperty *Prop);
-	int GetIntProperty(class UProperty * Prop);
-	struct FScriptInterface* GetInterfaceProperty(class UProperty *Prop);
-	float GetFloatProperty(class UProperty *Prop);
-	struct FScriptDelegate* GetDelegateProperty(class UProperty *Prop);
-	unsigned char GetByteProperty(class UProperty * Prop);
-	bool GetBoolProperty(class UBoolProperty *Prop);
-	void* GetPropertyAddress(class UProperty* Prop);
-	py::object GetArrayProperty(class UArrayProperty *Prop);
-	pybind11::object GetProperty(class UProperty * Prop);
+	void* GetPropertyAddress(class UProperty* Prop, int idx);
+	py::object GetProperty(class UProperty* Prop);
+	void SetProperty(class UProperty* Prop, const py::object& Val);
 
-	void SetProperty(class UStructProperty *Prop, const py::object& Val);
-	void SetProperty(class UStrProperty *Prop, const py::object& Val);
-	void SetProperty(class UObjectProperty *Prop, const py::object& Val);
-	void SetProperty(class UComponentProperty *Prop, const py::object& Val);
-	void SetProperty(class UClassProperty *Prop, const py::object& Val);
-	void SetProperty(class UNameProperty *Prop, const py::object& Val);
-	void SetProperty(class UInterfaceProperty *Prop, const py::object& Val);
-	void SetProperty(class UDelegateProperty *Prop, const py::object& Val);
-	void SetProperty(class UFloatProperty *Prop, const py::object& Val);
-	void SetProperty(class UIntProperty *Prop, const py::object& Val);
-	void SetProperty(class UByteProperty *Prop, const py::object& Val);
-	void SetProperty(class UBoolProperty *boolProp, const py::object& Val);
-	void SetProperty(class UArrayProperty *Prop, const py::object& Val);
-	void SetProperty(class UProperty *Prop, const py::object& val);
+	py::object GetStructProperty(class UProperty *Prop, int idx);
+	py::object GetStrProperty(class UProperty *Prop, int idx);
+	py::object GetObjectProperty(class UProperty *Prop, int idx);
+	py::object GetComponentProperty(class UProperty *Prop, int idx);
+	py::object GetClassProperty(class UProperty *Prop, int idx);
+	py::object GetNameProperty(class UProperty *Prop, int idx);
+	py::object GetInterfaceProperty(class UProperty *Prop, int idx);
+	py::object GetDelegateProperty(class UProperty *Prop, int idx);
+	py::object GetFloatProperty(class UProperty *Prop, int idx);
+	py::object GetIntProperty(class UProperty *Prop, int idx);
+	py::object GetByteProperty(class UProperty *Prop, int idx);
+	py::object GetBoolProperty(class UProperty *Prop, int idx);
+	py::object GetArrayProperty(class UProperty *Prop, int idx);
+
+	void SetStructProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetStrProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetObjectProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetComponentProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetClassProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetNameProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetInterfaceProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetDelegateProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetFloatProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetIntProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetByteProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetBoolProperty(class UProperty* Prop, int idx, const py::object& Val);
+	void SetArrayProperty(class UProperty* Prop, int idx, const py::object& Val);
 };
 
 // 0x003C

--- a/src/include/UnrealEngine/Core/Core_classes.h
+++ b/src/include/UnrealEngine/Core/Core_classes.h
@@ -247,7 +247,7 @@ public:
 	bool IsA(UClass* PClass) const;
 	class UPackage* GetPackageObject() const;
 	static UClass* StaticClass();
-	static std::vector<UObject*> FindAll(char* InStr);
+	static std::vector<UObject*> FindAll(char* InStr, bool IncludeSubclasses);
 
 	py::object GetProperty(std::string PropName);
 	void SetProperty(std::string& PropName, const py::object& Val);

--- a/src/include/stdafx.h
+++ b/src/include/stdafx.h
@@ -2,7 +2,7 @@
 
 #define VERSION_MAJOR	0
 #define VERSION_MINOR	7
-#define VERSION_PATCH	9
+#define VERSION_PATCH	10
 
 #include <SDKDDKVer.h>
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
As well as a few other small misc tweaks.

Adds support for static array properties - get as a list including null values, set as a sequence that's shorter than or equal to the array length (errors if longer).
Adds an optional `IncludeSubclasses` argument to `unrealsdk.FindAll()`.
Fixes C2102/C4238, allowing actually compiling in conformance mode again.