### PR TITLE
fix: wine proper exception handle

### DIFF
--- a/src/include/pybind11/pybind11.h
+++ b/src/include/pybind11/pybind11.h
@@ -681,6 +681,14 @@ protected:
 			e.restore();
 			return nullptr;
 		}
+		catch (const builtin_exception& e) {
+			e.set_error();
+			return nullptr;
+		}
+		catch (const std::exception& e) {
+			PyErr_SetString(PyExc_RuntimeError, e.what());
+			return nullptr;
+		}
 		catch (...) {
 			/* When an exception is caught, give each registered exception
 			   translator a chance to translate it to a Python exception


### PR DESCRIPTION
Fixes #83

For some reason
```
     catch (...) { std::exception_ptr ptr = std::current_exception(); }
```
does not work as intended (ptr is always null, maybe there is an issue in wine's `__ExceptionPtrCurrentException`  implementation, can't say for sure).

So to get it working properly on wine, exception in pybind11 should be handled explicitly.